### PR TITLE
Multi-line text parsing

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -7,7 +7,9 @@ use Medology\GherkinCsFixer\Exceptions\FileNotFound;
 use Medology\GherkinCsFixer\Exceptions\FileWriteException;
 use Medology\GherkinCsFixer\Exceptions\InvalidKeywordException;
 use Medology\GherkinCsFixer\Fixers\FixerFactory;
+use Medology\GherkinCsFixer\Fixers\MultilineFixer;
 use Medology\GherkinCsFixer\Fixers\TableFixer;
+use Medology\GherkinCsFixer\Parsers\MultilineParser;
 use Medology\GherkinCsFixer\Parsers\StepParser;
 use Medology\GherkinCsFixer\Parsers\TableParser;
 
@@ -25,8 +27,14 @@ class Application
     /** @var TableParser Instance of TableParser */
     private $tableParser;
 
+    /** @var MultilineParser Instance of MultilineParser */
+    private $multilineParser;
+
     /** @var TableFixer Instance of TableFixer */
     private $tableFixer;
+
+    /** @var MultilineFixer Instance of MultilineFixer */
+    private $multilineFixer;
 
     /**
      * Application constructor.
@@ -39,6 +47,8 @@ class Application
         $this->stepParser = new StepParser();
         $this->tableParser = new TableParser();
         $this->tableFixer = new TableFixer();
+        $this->multilineFixer = new MultilineFixer();
+        $this->multilineParser = new MultilineParser();
     }
 
     /**
@@ -86,6 +96,9 @@ class Application
         $stepDto = $this->stepParser->run($fileReader->current());
         if ($stepDto->getKeyword() == 'Table') {
             return $this->tableFixer->run($this->tableParser->run($fileReader));
+        }
+        if ($stepDto->getKeyword() == 'Multiline') {
+            return $this->multilineFixer->run($this->multilineParser->run($fileReader));
         }
 
         $fileReader->next();

--- a/src/Dto/MultilineDto.php
+++ b/src/Dto/MultilineDto.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Medology\GherkinCsFixer\Dto;
+
+/**
+ * DTO class to carry multiple line text information.
+ */
+class MultilineDto
+{
+    /** @var string[] List of text rows. */
+    private $rows;
+
+    /**
+     * Fill the properties from array.
+     *
+     * @param string[] $rows  List of text rows
+     */
+    public function __construct(array $rows)
+    {
+        $this->rows = $rows;
+    }
+
+    /**
+     * Gets the text rows.
+     *
+     * @return array
+     */
+    public function getContent(): array
+    {
+        return $this->rows;
+    }
+}

--- a/src/Dto/StepDto.php
+++ b/src/Dto/StepDto.php
@@ -19,8 +19,14 @@ class StepDto
         'When',
         'Then',
         'And',
-        'But',
-        '#',
+        'But'
+    ];
+
+    /** @var array List of special characters that are not actually step keywords. */
+    public const SYMBOL_KEYWORDS = [
+        '#'    => 'Comment', // Comment lines
+        '|'    => 'Table',   // Table pipe
+        '"""'  => 'Multiline' // Multiline text start
     ];
 
     /** @var string Step line without keyword prefix. */
@@ -38,15 +44,15 @@ class StepDto
     {
         if (empty($content['keyword'])) {
             $this->keyword = 'None';
-            $this->body = $content['body'] ?? '';
-        } elseif ($content['keyword'] == '|') {
-            $this->keyword = 'Table';
-        } elseif (!in_array($content['keyword'], self::STEP_KEYWORDS)) {
-            throw new InvalidKeywordException('Mismatched parsed keyword: '.$content['keyword']);
+        } elseif (isset(self::SYMBOL_KEYWORDS[$content['keyword']])) {
+            $this->keyword = self::SYMBOL_KEYWORDS[$content['keyword']];
+        } elseif (in_array($content['keyword'], self::STEP_KEYWORDS)) {
+            $this->keyword = $content['keyword'];
         } else {
-            $this->keyword = $content['keyword'] == '#' ? 'Pound' : $content['keyword'];
-            $this->body = $content['body'];
+            throw new InvalidKeywordException('Mismatched parsed keyword: '.$content['keyword']);
         }
+
+        $this->body = $content['body'] ?? '';
     }
 
     /**

--- a/src/Fixers/CommentStepFixer.php
+++ b/src/Fixers/CommentStepFixer.php
@@ -5,7 +5,7 @@ namespace Medology\GherkinCsFixer\Fixers;
 /**
  * Fixer class for commented lines.
  */
-class PoundStepFixer extends StepFixer
+class CommentStepFixer extends StepFixer
 {
     protected $padding = 0;
     protected $keyword = '#';

--- a/src/Fixers/MultilineFixer.php
+++ b/src/Fixers/MultilineFixer.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Medology\GherkinCsFixer\Fixers;
+
+use Medology\GherkinCsFixer\Dto\MultilineDto;
+
+/**
+ * Fixes the multiple line text formatting.
+ */
+class MultilineFixer
+{
+    /** @var int Padding value from left */
+    private const PADDING = 13;
+
+    /** @var string Text block starting and ending */
+    private const KEYWORD = '"""';
+
+    /**
+     * Reformat the text.
+     *
+     * @param  MultilineDto $dto Text content dto.
+     * @return string
+     */
+    public function run(MultilineDto $dto): string
+    {
+        $block_tag = str_pad(self::KEYWORD, self::PADDING, " ", STR_PAD_LEFT) .PHP_EOL;
+        return $block_tag . implode('', $dto->getContent()) . $block_tag;
+    }
+}

--- a/src/Parsers/MultilineParser.php
+++ b/src/Parsers/MultilineParser.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Medology\GherkinCsFixer\Parsers;
+
+use Generator;
+use Medology\GherkinCsFixer\Dto\MultilineDto;
+
+/**
+ * Parse consecutive lines as text and fix the formatting.
+ */
+class MultilineParser
+{
+    /**
+     * Parses the text block and return reformatted new one.
+     *
+     * @param  Generator $fileReader File streamer
+     * @return MultilineDTO
+     */
+    public function run(Generator $fileReader): MultilineDTO
+    {
+        // Skip the start line (starting """)
+        $fileReader->next();
+        $rows = [];
+        while ('"""' != trim(($line = $fileReader->current()))) {
+            $rows[] = $line;
+            $fileReader->next();
+        }
+        // Skip the ending line
+        $fileReader->next();
+
+        return new MultilineDTO($rows);
+    }
+}

--- a/src/Parsers/StepParser.php
+++ b/src/Parsers/StepParser.php
@@ -19,7 +19,9 @@ class StepParser
     public function __construct()
     {
         $this->regex = '/^(\s+)?(?P<keyword>' .
-            implode('|', StepDto::STEP_KEYWORDS) . '|\|)(?P<body>.*)/';
+            implode('|', StepDto::STEP_KEYWORDS) . '|' .
+            implode('|\\', array_keys(StepDto::SYMBOL_KEYWORDS)) .
+            ')(?P<body>.*)/';
     }
 
     /**


### PR DESCRIPTION
### Problem
The script doesn't recognize multiple line text blocks like : 

    """
    Email Title

    Email Body
    """
And see empty lines as unnecessary and removes.

### Solution
Added text support so, script parses multipleline text properly and doesn't remove empty lines.
