### PR TITLE
Indentation for PyStrings and | symbol escape problem

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -44,7 +44,7 @@ class Application
     /**
      * Application constructor.
      *
-     * @param string[] $files List of the files to be fixed.
+     * @param  string[]                $files List of the files to be fixed.
      * @throws InvalidKeywordException When StepDto keyword mismatch
      */
     public function __construct(array $files)

--- a/src/Dto/PyStringsDto.php
+++ b/src/Dto/PyStringsDto.php
@@ -19,8 +19,8 @@ class PyStringsDto
     /**
      * Fill the properties from array.
      *
-     * @param array[] $rows List of text lines and padding from left
-     * @param int $padding Initial padding of the starting tag from left
+     * @param array[] $rows    List of text lines and padding from left
+     * @param int     $padding Initial padding of the starting tag from left
      */
     public function __construct(array $rows, int $padding = 0)
     {

--- a/src/Dto/PyStringsDto.php
+++ b/src/Dto/PyStringsDto.php
@@ -13,14 +13,19 @@ class PyStringsDto
     /** @var string Text block starting and ending */
     public const KEYWORD = '"""';
 
+    /** @var int Initial padding of the starting tag from left */
+    private $padding = 0;
+
     /**
      * Fill the properties from array.
      *
-     * @param string[] $rows List of text rows
+     * @param array[] $rows List of text lines and padding from left
+     * @param int $padding Initial padding of the starting tag from left
      */
-    public function __construct(array $rows)
+    public function __construct(array $rows, int $padding = 0)
     {
         $this->rows = $rows;
+        $this->padding = $padding;
     }
 
     /**
@@ -31,5 +36,15 @@ class PyStringsDto
     public function getContent(): array
     {
         return $this->rows;
+    }
+
+    /**
+     * left starting tag padding value.
+     *
+     * @return int
+     */
+    public function getHeaderPadding(): int
+    {
+        return $this->padding;
     }
 }

--- a/src/Dto/StepDto.php
+++ b/src/Dto/StepDto.php
@@ -24,6 +24,7 @@ class StepDto
 
     /** @var array List of special characters that are not actually step keywords. */
     public const SYMBOL_KEYWORDS = [
+        '@'                    => 'Tag',    // Scenario tags
         '#'                    => 'Comment', // Comment lines
         '|'                    => 'Table',   // Table pipe
         PyStringsDto::KEYWORD  => PyStringsDto::KEYWORD, // PyStrings
@@ -31,8 +32,12 @@ class StepDto
 
     /** @var string Step line without keyword prefix. */
     private $body = '';
+
     /** @var string Step line keyword. */
     private $keyword;
+
+    /** @var bool New line before the step or not. */
+    private $line_break;
 
     /**
      * Fill the properties from array.
@@ -53,6 +58,7 @@ class StepDto
         }
 
         $this->body = $content['body'] ?? '';
+        $this->line_break = $content['line_break'] ?? false;
     }
 
     /**
@@ -73,5 +79,15 @@ class StepDto
     public function getBody(): string
     {
         return $this->body;
+    }
+
+    /**
+     * Insert new line before ?
+     *
+     * @return bool
+     */
+    public function hasLineBreak(): bool
+    {
+        return $this->line_break;
     }
 }

--- a/src/Fixers/BackgroundStepFixer.php
+++ b/src/Fixers/BackgroundStepFixer.php
@@ -9,12 +9,5 @@ class BackgroundStepFixer extends StepFixer
 {
     protected $padding = 2;
     protected $keyword = 'Background';
-
-    /**
-     * {@inheritdoc}
-     */
-    public function run(): string
-    {
-        return PHP_EOL.parent::run();
-    }
+    protected $newline = true;
 }

--- a/src/Fixers/CommentStepFixer.php
+++ b/src/Fixers/CommentStepFixer.php
@@ -7,6 +7,6 @@ namespace Medology\GherkinCsFixer\Fixers;
  */
 class CommentStepFixer extends StepFixer
 {
-    protected $padding = 0;
+    protected $padding = 8;
     protected $keyword = '#';
 }

--- a/src/Fixers/FixerFactory.php
+++ b/src/Fixers/FixerFactory.php
@@ -21,6 +21,6 @@ class FixerFactory
     {
         $fixerClass = '\Medology\GherkinCsFixer\Fixers\\'.$stepDTO->getKeyword().'StepFixer';
 
-        return new $fixerClass($stepDTO->getBody());
+        return new $fixerClass($stepDTO);
     }
 }

--- a/src/Fixers/PyStringsFixer.php
+++ b/src/Fixers/PyStringsFixer.php
@@ -10,7 +10,7 @@ use Medology\GherkinCsFixer\Dto\PyStringsDto;
 class PyStringsFixer
 {
     /** @var int Padding value from left */
-    private const PADDING = 13;
+    private const PADDING = 10;
 
     /**
      * Reformat the text.
@@ -20,8 +20,16 @@ class PyStringsFixer
      */
     public function run(PyStringsDto $dto): string
     {
-        $block_tag = str_pad(PyStringsDto::KEYWORD, self::PADDING, ' ', STR_PAD_LEFT) .PHP_EOL;
+        $block_tag = str_pad(
+                PyStringsDto::KEYWORD,
+                strlen(PyStringsDto::KEYWORD) + self::PADDING,
+                ' ',
+                STR_PAD_LEFT) . PHP_EOL;
+        $text = '';
+        foreach ($dto->getContent() as $row_text) {
+            $text .= str_pad($row_text, strlen($row_text) + self::PADDING, ' ', STR_PAD_LEFT);
+        }
 
-        return $block_tag . implode('', $dto->getContent()) . $block_tag;
+        return  $block_tag . $text . $block_tag;
     }
 }

--- a/src/Fixers/PyStringsFixer.php
+++ b/src/Fixers/PyStringsFixer.php
@@ -29,26 +29,14 @@ class PyStringsFixer
                 strlen(PyStringsDto::KEYWORD) + self::PADDING,
                 ' ',
                 STR_PAD_LEFT) . PHP_EOL;
+
         $text = '';
-        $leftPadding = $this->calculateLeftPadding();
-        foreach ($this->dto->getContent() as $row_text) {
-            $text .= str_pad($row_text, strlen($row_text) + $leftPadding, ' ', STR_PAD_LEFT);
+        $start_padding = $this->dto->getHeaderPadding();
+        foreach ($this->dto->getContent() as $row) {
+            $leftPadding = self::PADDING + max($row['padding'] - $start_padding,0);
+            $text .= str_repeat(' ', $leftPadding) . $row['text'] . PHP_EOL;
         }
 
         return  $block_tag . $text . $block_tag;
-    }
-
-    /**
-     * Calculate the minimum left padding from the left side.
-     *
-     * @return int
-     */
-    private function calculateLeftPadding(): int
-    {
-        $padding = min(array_map(function ($value) {
-            return strspn($value, ' ');
-        }, $this->dto->getContent()));
-
-        return $padding > self::PADDING ? 0 : self::PADDING - $padding;
     }
 }

--- a/src/Fixers/PyStringsFixer.php
+++ b/src/Fixers/PyStringsFixer.php
@@ -33,7 +33,7 @@ class PyStringsFixer
         $text = '';
         $start_padding = $this->dto->getHeaderPadding();
         foreach ($this->dto->getContent() as $row) {
-            $leftPadding = self::PADDING + max($row['padding'] - $start_padding,0);
+            $leftPadding = self::PADDING + max($row['padding'] - $start_padding, 0);
             $text .= str_repeat(' ', $leftPadding) . $row['text'] . PHP_EOL;
         }
 

--- a/src/Fixers/PyStringsFixer.php
+++ b/src/Fixers/PyStringsFixer.php
@@ -45,7 +45,7 @@ class PyStringsFixer
      */
     private function calculateLeftPadding(): int
     {
-        $padding =  min(array_map(function ($value) {
+        $padding = min(array_map(function ($value) {
             return strspn($value, ' ');
         }, $this->dto->getContent()));
 

--- a/src/Fixers/PyStringsFixer.php
+++ b/src/Fixers/PyStringsFixer.php
@@ -12,6 +12,9 @@ class PyStringsFixer
     /** @var int Padding value from left */
     private const PADDING = 10;
 
+    /** @var PyStringsDto PyStrings Data Object */
+    private $dto;
+
     /**
      * Reformat the text.
      *
@@ -20,16 +23,32 @@ class PyStringsFixer
      */
     public function run(PyStringsDto $dto): string
     {
+        $this->dto = $dto;
         $block_tag = str_pad(
                 PyStringsDto::KEYWORD,
                 strlen(PyStringsDto::KEYWORD) + self::PADDING,
                 ' ',
                 STR_PAD_LEFT) . PHP_EOL;
         $text = '';
-        foreach ($dto->getContent() as $row_text) {
-            $text .= str_pad($row_text, strlen($row_text) + self::PADDING, ' ', STR_PAD_LEFT);
+        $leftPadding = $this->calculateLeftPadding();
+        foreach ($this->dto->getContent() as $row_text) {
+            $text .= str_pad($row_text, strlen($row_text) + $leftPadding, ' ', STR_PAD_LEFT);
         }
 
         return  $block_tag . $text . $block_tag;
+    }
+
+    /**
+     * Calculate the minimum left padding from the left side.
+     *
+     * @return int
+     */
+    private function calculateLeftPadding(): int
+    {
+        $padding =  min(array_map(function ($value) {
+            return strspn($value, ' ');
+        }, $this->dto->getContent()));
+
+        return $padding > self::PADDING ? 0 : self::PADDING - $padding;
     }
 }

--- a/src/Fixers/StepFixer.php
+++ b/src/Fixers/StepFixer.php
@@ -2,6 +2,8 @@
 
 namespace Medology\GherkinCsFixer\Fixers;
 
+use Medology\GherkinCsFixer\Dto\StepDto;
+
 /**
  * Abstract Fixer main class.
  *
@@ -13,14 +15,18 @@ abstract class StepFixer
     /** @var string Step body. */
     protected $step_body;
 
+    /** @var bool Has new line before this step. */
+    protected $newline = false;
+
     /**
      * Assign the body variable.
      *
-     * @param string $step_body
+     * @param StepDto $stepDto All the information about this step
      */
-    public function __construct(string $step_body)
+    public function __construct(StepDto $stepDto)
     {
-        $this->step_body = $step_body;
+        $this->step_body = $stepDto->getBody();
+        $this->newline = $stepDto->hasLineBreak() && $this->newline;
     }
 
     /**
@@ -30,6 +36,10 @@ abstract class StepFixer
      */
     public function run(): string
     {
-        return str_repeat(' ', $this->padding) . $this->keyword . $this->step_body . PHP_EOL;
+        return ($this->newline ? PHP_EOL : "") .
+            str_repeat(' ', $this->padding) .
+            $this->keyword .
+            $this->step_body .
+            PHP_EOL;
     }
 }

--- a/src/Fixers/StepFixer.php
+++ b/src/Fixers/StepFixer.php
@@ -36,7 +36,7 @@ abstract class StepFixer
      */
     public function run(): string
     {
-        return ($this->newline ? PHP_EOL : "") .
+        return ($this->newline ? PHP_EOL : '') .
             str_repeat(' ', $this->padding) .
             $this->keyword .
             $this->step_body .

--- a/src/Fixers/TagStepFixer.php
+++ b/src/Fixers/TagStepFixer.php
@@ -3,11 +3,11 @@
 namespace Medology\GherkinCsFixer\Fixers;
 
 /**
- * Fixer class for Scenario keyword.
+ * Fixer class for scenario tags.
  */
-class ScenarioStepFixer extends StepFixer
+class TagStepFixer extends StepFixer
 {
     protected $padding = 2;
-    protected $keyword = 'Scenario';
+    protected $keyword = '@';
     protected $newline = true;
 }

--- a/src/Parsers/PyStringsParser.php
+++ b/src/Parsers/PyStringsParser.php
@@ -25,8 +25,8 @@ class PyStringsParser
         $rows = [];
         while (PyStringsDto::KEYWORD != trim($fileReader->current())) {
             $rows[] = [
-                'text' => trim($fileReader->current()),
-                'padding' => strspn($fileReader->current(), ' ')
+                'text'    => trim($fileReader->current()),
+                'padding' => strspn($fileReader->current(), ' '),
             ];
 
             $fileReader->next();

--- a/src/Parsers/PyStringsParser.php
+++ b/src/Parsers/PyStringsParser.php
@@ -19,15 +19,21 @@ class PyStringsParser
     public function run(Generator $fileReader): PyStringsDto
     {
         // Skip the starting line of the block
+        $header_padding = strspn($fileReader->current(), ' ');
         $fileReader->next();
+
         $rows = [];
-        while (PyStringsDto::KEYWORD != trim(($line = $fileReader->current()))) {
-            $rows[] = $line;
+        while (PyStringsDto::KEYWORD != trim($fileReader->current())) {
+            $rows[] = [
+                'text' => trim($fileReader->current()),
+                'padding' => strspn($fileReader->current(), ' ')
+            ];
+
             $fileReader->next();
         }
         // Skip the closing line of the block
         $fileReader->next();
 
-        return new PyStringsDto($rows);
+        return new PyStringsDto($rows, $header_padding);
     }
 }

--- a/src/Parsers/StepParser.php
+++ b/src/Parsers/StepParser.php
@@ -27,10 +27,10 @@ class StepParser
     /**
      * Parses the line from the file and return as StepDTO.
      *
-     * @param string $raw_step Raw text line from the file
-     * @param StepDto $previousStep Previous step information
-     * @return StepDto
+     * @param  string                  $raw_step     Raw text line from the file
+     * @param  StepDto                 $previousStep Previous step information
      * @throws InvalidKeywordException When the keyword mismatched with check.
+     * @return StepDto
      */
     public function run(string $raw_step, StepDto $previousStep): StepDto
     {

--- a/src/Parsers/StepParser.php
+++ b/src/Parsers/StepParser.php
@@ -27,14 +27,16 @@ class StepParser
     /**
      * Parses the line from the file and return as StepDTO.
      *
-     * @param  string                  $raw_step Raw text line from the file
-     * @throws InvalidKeywordException When the keyword mismatched with check.
+     * @param string $raw_step Raw text line from the file
+     * @param StepDto $previousStep Previous step information
      * @return StepDto
+     * @throws InvalidKeywordException When the keyword mismatched with check.
      */
-    public function run(string $raw_step): StepDto
+    public function run(string $raw_step, StepDto $previousStep): StepDto
     {
-        return preg_match($this->regex, $raw_step, $m)
-            ? new StepDto($m)
-            : new StepDto(['body'=>$raw_step]);
+        $dto_data = preg_match($this->regex, $raw_step, $m) ? $m : ['body'=>$raw_step];
+        $dto_data['line_break'] = $previousStep->getKeyword() != 'Tag';
+
+        return new StepDto($dto_data);
     }
 }

--- a/src/Parsers/TableParser.php
+++ b/src/Parsers/TableParser.php
@@ -48,7 +48,10 @@ class TableParser
         if (!preg_match('/^(\s+)?\|(?P<step>.*)/', $table_row)) {
             return null;
         }
-        $cells = preg_split('/\s*\|\s*/', $table_row);
+
+        // Split by pipe
+        $cells = preg_split('~\\\\.(*SKIP)(*FAIL)|\|~s', $table_row);
+        $cells = array_map('trim', $cells);
         array_pop($cells);
         array_shift($cells);
 


### PR DESCRIPTION
## After fixing file was looking like this:

```gherkin
 Background:
    Given something
      When Something happens
# here is comment 1
      Then this table should exist::
         | something | another thing |
         # here another comment
      Then something else with:
           """
  some text

some more text
           """
```

## Which should look like this:

```gherkin
 Background:
     Given something
      When Something happens
         # here is comment 1
      Then this table should exist::
         | something | another thing |
         # here another comment
      Then something else with:
           """
             some text

           some more text
           """
```
### Solution
- Fixed the commented lines as well as commented table steps on to align on the same column line
- PyStrings indentation will be aligned to the opening (`"""`) tag


### Updated:
- Fixed the new issue that been discovered. Escaped `|` characters inside a table was causing a problem.

```gherkin
 Examples:
        | hours                                        | dayInfo1 | 
        | M-F 8:30 am-5:30 pm                          | Monday   | 
        | M-F 7:30 am-5:30 pm \| Sa 8\|:00 am-12:00 pm | Monday   |
```

- Added scenario tag support. Script had no recognition of tags and adding a new line before scenarios. Fixed this issue

### Before
```gherkin

         @firstTag

       @secondTag

   Scenario:
     Given something
      When Something happens
         # here is comment 1
      Then this table should exist::
         | something | another thing |
         # here another comment
```

### After
```gherkin
   @firstTag
   @secondTag
   Scenario:
     Given something
      When Something happens
         # here is comment 1
      Then this table should exist::
         | something | another thing |
         # here another comment
```
