### PR TITLE
Fix StyleCI configuration

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,11 @@
+preset: recommended
+disabled:
+  - blank_line_after_opening_tag
+  - concat_without_spaces
+  - phpdoc_separation
+  - post_increment
+  - single_blank_line_before_namespace
+enabled:
+  - blank_line_before_break
+  - blank_line_before_continue
+  - blank_line_before_declare


### PR DESCRIPTION
For https://github.com/Medology/stdcheck.com/issues/9429

Fix StyleCI configuration error:

```
Config Issue
The provided fixer 'simplified_null_return' cannot be disabled unless it was already enabled by your preset.
```
