### PR TITLE
Fix multibyte support for table

### DIFF
--- a/src/Parsers/TableParser.php
+++ b/src/Parsers/TableParser.php
@@ -72,8 +72,8 @@ class TableParser
             foreach ($rowDto->getCells() as $col => $cell) {
                 $columns_width[$col] =
                     isset($columns_width[$col])
-                    ? max(strlen($cell), $columns_width[$col])
-                    : strlen($cell);
+                    ? max(mb_strlen($cell), $columns_width[$col])
+                    : mb_strlen($cell);
             }
         }
 

--- a/tests/Parsers/TableParser/ComputeColumnWidthsTest.php
+++ b/tests/Parsers/TableParser/ComputeColumnWidthsTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Parsers\TableParser;
+
+use Medology\GherkinCsFixer\Dto\TableRowDto;
+use Medology\GherkinCsFixer\Parsers\TableParser;
+use ReflectionException;
+use Tests\TestCase;
+
+/**
+ * @covers Medology\GherkinCsFixer\Parsers\TableParser::computeColumnWidths
+ */
+class ComputeColumnWidthsTest extends TestCase
+{
+    /**
+     * Test the column length should be calculated correctly with multibyte characters.
+     * - Without proper multibyte support, the column length is 10
+     * - With proper multibyte support, the column length is 8.
+     *
+     * @throws ReflectionException
+     */
+    public function testColumnWidthShouldBeCalculatedCorrectForColumnWithMultiBytes()
+    {
+        $tableRowDtos = [
+            new TableRowDto(['keyword']),
+            new TableRowDto(['Ègg, Ýup']),
+            new TableRowDto(['ègg, ýup']),
+            new TableRowDto(['èGG, ýUP']),
+        ];
+
+        $columnWidths = $this->invokeMethod(new TableParser(), 'computeColumnWidths', [$tableRowDtos]);
+
+        $this->assertEquals($columnWidths, [8]);
+    }
+}


### PR DESCRIPTION
For https://github.com/Medology/gherkin-cs-fixer/issues/25

### Problem
The max column width is not calculated correctly when there's mutlibyte string in it

### Fix
* Fixed the logic to use `mb_strlen` to calculate the length of the cell in the table
* Added an unit test 