### PR TITLE
Add mbstring extension to the image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,19 @@
 ARG PHP_IMAGE
 FROM ${PHP_IMAGE}
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends --no-install-suggests \
+    #
+    # Multibyte string extension
+    php${PHP_VERSION}-mbstring && \
+    #
+    # Cleanup
+    apt-get remove -y && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+    #
+
 COPY . /project
 COPY ./docker/entrypoint.sh /usr/local/bin/entrypoint-gherkin-fixer.sh
 COPY ./docker/gherkin-cs-fixer /usr/local/bin/gherkin-cs-fixer


### PR DESCRIPTION
For https://github.com/Medology/gherkin-cs-fixer/issues/25

### Problem
The `mbstring` extension is missing in the docker image that the gherkin-cs-fixer is running with. The unit test in previous PR that cover the mb_strlen() passed because the php unit image has the mb_string extension.

### Fix
Add the mbstring extension when building the image