### PR TITLE
Fix the multibyte problem with multibyte exist in table body

### DIFF
--- a/src/Fixers/TableFixer.php
+++ b/src/Fixers/TableFixer.php
@@ -44,7 +44,7 @@ class TableFixer
     private function setCellPadding(TableRowDto $rowDto): array
     {
         return array_map(function ($column, $cell) {
-            return str_pad($cell, $this->dto->getColumnLength($column), ' ', STR_PAD_RIGHT);
+            return $cell . str_repeat(' ', $this->dto->getColumnLength($column) - mb_strlen($cell));
         }, array_keys($rowDto->getCells()), $rowDto->getCells());
     }
 

--- a/tests/Fixers/TableFixer/SetCellPadding.php
+++ b/tests/Fixers/TableFixer/SetCellPadding.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Parsers\TableParser;
+
+use Medology\GherkinCsFixer\Dto\TableDto;
+use Medology\GherkinCsFixer\Dto\TableRowDto;
+use Medology\GherkinCsFixer\Fixers\TableFixer;
+use Medology\GherkinCsFixer\Parsers\TableParser;
+use ReflectionException;
+use Tests\TestCase;
+
+/**
+ * @covers \Medology\GherkinCsFixer\Fixers\TableFixer::setCellPadding
+ */
+class SetCellPadding extends TestCase
+{
+    /**
+     * Test the cells should be padded correctly with/without multibyte string inside the table node.
+     *
+     * @param array $tableDtoContents the contents of the TableDto that will be tested
+     * @param array $formattedCells   the expected formatted cells
+     *
+     * @throws ReflectionException
+     *
+     * @dataProvider tableRowsProvider
+     */
+    public function testSetCellPaddingParsedCorrectlyForCellWithMultiBytes(array $tableDtoContents, array $formattedCells)
+    {
+        $tableRowDtos = array_map(function ($tableDtoContent) {
+            return new TableRowDto([$tableDtoContent]);
+        }, $tableDtoContents);
+
+        $columnWidths = $this->invokeMethod(new TableParser(), 'computeColumnWidths', [$tableRowDtos]);
+
+        $tableDto = new TableDto($tableRowDtos, $columnWidths);
+
+        $tableFixer = new TableFixer();
+
+        $tableFixer->run($tableDto);
+
+        $output = array_map(function ($tableRowDto) use ($tableFixer) {
+            return $this->invokeMethod($tableFixer, 'setCellPadding', [$tableRowDto]);
+        }, $tableRowDtos);
+
+        $this->assertEquals($formattedCells, $output);
+    }
+
+    /**
+     * Provide all test cases for the table rows with/without multibyte string.
+     *
+     * @return array
+     */
+    public function tableRowsProvider(): array
+    {
+        return [
+            'None multibyte' => [
+                [
+                    'keyword',
+                    'egg, yup',
+                ],
+                [
+                    ['keyword '],
+                    ['egg, yup'],
+                ],
+            ],
+            'Only header in multibyte' => [
+                [
+                    'keywörd',
+                    'egg, yup',
+                ],
+                [
+                    ['keywörd '],
+                    ['egg, yup'],
+                ],
+            ],
+            'Only header in multibyte with multiple rows' => [
+                [
+                    'keywörd',
+                    'egg, yup',
+                    'egg, yup 2',
+                ],
+                [
+                    ['keywörd   '],
+                    ['egg, yup  '],
+                    ['egg, yup 2'],
+                ],
+            ],
+            'Only content in multibyte' => [
+                [
+                    'keyword',
+                    'egg, yöp',
+                ],
+                [
+                    ['keyword '],
+                    ['egg, yöp'],
+                ],
+            ],
+            'Only content in multibyte with multiple rows' => [
+                [
+                    'keyword',
+                    'egg, yöp',
+                    'egg, yöp 2',
+                ],
+                [
+                    ['keyword   '],
+                    ['egg, yöp  '],
+                    ['egg, yöp 2'],
+                ],
+            ],
+            'All multibyte' => [
+                [
+                    'keywörd',
+                    'egg, yöp',
+                ],
+                [
+                    ['keywörd '],
+                    ['egg, yöp'],
+                ],
+            ],
+            'All multibyte with multiple rows' => [
+                [
+                    'keywörd',
+                    'egg, yöp',
+                    'egg, yöp 2',
+                ],
+                [
+                    ['keywörd   '],
+                    ['egg, yöp  '],
+                    ['egg, yöp 2'],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
For https://github.com/Medology/gherkin-cs-fixer/issues/25

### Problem
When there's multibyte string in the body (which is not the header) of the TableNode, the width is not parsed correctly

### Fix
* Updated the `setCellPadding()` function, since there's no multibyte version of `strpad`, I created the multibyte right_padding logic for that
* Added unit tests.