### PR TITLE
Remove styleCI from pullapprove config requirements

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -19,6 +19,3 @@ pullapprove_conditions:
   - condition: "'Do Not Review' not in labels"
     unmet_status: pending
     explanation: "Not ready for review"
-  - condition: "'continuous-integration/styleci/pr' in statuses.succeeded or 'Force Review' in labels"
-    unmet_status: pending
-    explanation: "StyleCI must pass before requesting review"

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,8 +1,0 @@
-preset: symfony
-
-disabled:
-  - unalign_double_arrow
-  - unalign_equals
-  - yoda_style
-  - single_line_throw
-  - concat_without_spaces


### PR DESCRIPTION
For #medology/general-issues/106
Remove StyleCI config from PullApprove configurations.